### PR TITLE
Minor naming fix

### DIFF
--- a/src/pages/settings/profile.tsx
+++ b/src/pages/settings/profile.tsx
@@ -324,7 +324,7 @@ const DeleteAccount: FC = () => {
                 I acknowledge that this action is irreversable and this will
                 delete all my data such as:
                 <br />
-                - Any purchases I&apos;ve made (for example for Spotistats Plus)
+                - Any purchases I&apos;ve made (for example for Stats.fm Plus)
                 <br />
                 - Any automatically syncing playlists I&apos;ve made
                 <br />

--- a/src/pages/settings/profile.tsx
+++ b/src/pages/settings/profile.tsx
@@ -324,7 +324,7 @@ const DeleteAccount: FC = () => {
                 I acknowledge that this action is irreversable and this will
                 delete all my data such as:
                 <br />
-                - Any purchases I&apos;ve made (for example for Stats.fm Plus)
+                - Any purchases I&apos;ve made (for example for stats.fm Plus)
                 <br />
                 - Any automatically syncing playlists I&apos;ve made
                 <br />


### PR DESCRIPTION
Changes a reference from Spotistats to Stats.fm when describing plus in the DeleteAccount function