### PR TITLE
Moved the year down in the dropdown.

### DIFF
--- a/src/pages/user/[id]/[[...deeplink]].tsx
+++ b/src/pages/user/[id]/[[...deeplink]].tsx
@@ -187,9 +187,9 @@ const User: NextPage<Props> = ({
       setAvailableRanges([
         BetterRange.TODAY,
         BetterRange.THIS_WEEK,
-        BetterRange.CURRENT_YEAR,
         BetterRange.WEEKS,
         BetterRange.MONTHS,
+        BetterRange.CURRENT_YEAR,
         BetterRange.LIFETIME,
       ]);
     }


### PR DESCRIPTION
[improvement: Moved the year timeframe down to make the order feel more natural](https://github.com/statsfm/web/commit/1a5536589a4e52b9861bda72300336d4129ffbf3)

The year was between "This week" and "4 weeks", it is now between "6 months" and "lifetime" as that makes more sense.