### PR TITLE
feat(user): store the selected timeframe in search params

### DIFF
--- a/src/components/User/TopAlbums.tsx
+++ b/src/components/User/TopAlbums.tsx
@@ -18,6 +18,7 @@ import {
   type TimeframeSelection,
   getTimeframeOptions,
   getTimeframeText,
+  getTimeframeQueryParam,
 } from './utils';
 import { NotEnoughData } from './NotEnoughData';
 
@@ -83,7 +84,8 @@ export const TopAlbums: FC<{
             )}
             <SectionToolbarInfoMenu>
               <ShareMenuItem
-                path={`/${userProfile.customId ?? userProfile.id}/albums`}
+                // eslint-disable-next-line prettier/prettier
+                path={`/${userProfile.customId ?? userProfile.id}/albums${getTimeframeQueryParam(timeframe)}`}
               />
             </SectionToolbarInfoMenu>
           </div>

--- a/src/components/User/TopArtists.tsx
+++ b/src/components/User/TopArtists.tsx
@@ -15,6 +15,7 @@ import { ShareMenuItem } from '../ShareMenuItem';
 import { ArtistCard, ArtistCardSkeleton } from '../Artist';
 import {
   getTimeframeOptions,
+  getTimeframeQueryParam,
   getTimeframeText,
   type TimeframeSelection,
 } from './utils';
@@ -83,7 +84,8 @@ export const TopArtists: FC<{
             )}
             <SectionToolbarInfoMenu>
               <ShareMenuItem
-                path={`/${userProfile.customId ?? userProfile.id}/artists`}
+                // eslint-disable-next-line prettier/prettier
+                path={`/${userProfile.customId ?? userProfile.id}/artists${getTimeframeQueryParam(timeframe)}`}
               />
             </SectionToolbarInfoMenu>
           </div>

--- a/src/components/User/TopTracks.tsx
+++ b/src/components/User/TopTracks.tsx
@@ -15,6 +15,7 @@ import { ShareMenuItem } from '../ShareMenuItem';
 import { TrackCard, TrackCardSkeleton } from '../Track';
 import {
   getTimeframeOptions,
+  getTimeframeQueryParam,
   getTimeframeText,
   type TimeframeSelection,
 } from './utils';
@@ -82,7 +83,8 @@ export const TopTracks: FC<{
             )}
             <SectionToolbarInfoMenu>
               <ShareMenuItem
-                path={`/${userProfile.customId ?? userProfile.id}/tracks`}
+                // eslint-disable-next-line prettier/prettier
+                path={`/${userProfile.customId ?? userProfile.id}/tracks${getTimeframeQueryParam(timeframe)}`}
               />
             </SectionToolbarInfoMenu>
           </div>

--- a/src/components/User/utils.ts
+++ b/src/components/User/utils.ts
@@ -94,6 +94,17 @@ export const getTimeframeOptions = (
   return { range: Range.LIFETIME };
 };
 
+export const getTimeframeQueryParam = (timeframe: TimeframeSelection) => {
+  if (timeframe.selected === 'APPLEMUSIC') {
+    return `?year=${timeframe.year}`;
+  }
+  if (timeframe.selected === 'RANGE') {
+    return `?range=${timeframe.range}`;
+  }
+  // TODO: handle custom
+  return '';
+};
+
 export const rangeToText = (range: BetterRange) => {
   if (range === BetterRange.TODAY) {
     return 'today';


### PR DESCRIPTION
This PR adds a query parameter that allows sharing (or even refreshing!) the user page without losing the set timeframe.

`range` is used for Spotify and `year` for Apple Music.