### PR TITLE
fix(user): center warning icon when quarantined

### DIFF
--- a/src/pages/user/[id]/[[...deeplink]].tsx
+++ b/src/pages/user/[id]/[[...deeplink]].tsx
@@ -473,8 +473,8 @@ const User: NextPage<Props> = ({
           <Container className="mt-8">
             {user.quarantined && (
               <section className="pb-10">
-                <div className="flex">
-                  <MdWarning className="mr-2 mt-1.5 text-white opacity-60" />
+                <div className="flex items-center">
+                  <MdWarning className="mr-2 text-white opacity-60" />
                   <p>This account&apos;s streams have been quarantined</p>
                   {/* TODO: Add info button with link to a support article or a popup message */}
                 </div>


### PR DESCRIPTION
before:
<img width="416" alt="image" src="https://github.com/statsfm/web/assets/20407566/253f5602-f913-46c7-8aec-c284239035be">

after:
<img width="418" alt="image" src="https://github.com/statsfm/web/assets/20407566/4f5438b1-993b-4616-b521-9048457524cc">
